### PR TITLE
Add Tim Jenness to author list

### DIFF
--- a/O3-1.tex
+++ b/O3-1.tex
@@ -21,15 +21,16 @@
 \begin{document}
 
 \title{The LSST Data Management System}
-\author{Mario~Juric,$^1$ Jeffrey Kantor,$^2$, K-T~Lim$^3$
+\author{Mario~Juric,$^1$ Jeffrey Kantor,$^2$, K-T~Lim,$^3$ Tim~Jenness$^4$
 \affil{$^1$University of Washington, Seattle, WA, U.S.A; \email{mjuric@astro.washington.edu}}
 \affil{$^2$LSST Project Management Office, Tucson, AZ, U.S.A.; \email{jkantor@lsst.org}}
-\affil{$^3$SLAC National Laboratory, Menlo Park, CA, U.S.A.; \email{ktl@slac.stanford.edu}}}
+\affil{$^3$SLAC National Laboratory, Menlo Park, CA, U.S.A.; \email{ktl@slac.stanford.edu}}
+\affil{$^2$LSST Project Management Office, Tucson, AZ, U.S.A.; \email{tjenness@lsst.org}}
+}
 
 % This section is for ADS Processing.  There must be one line per author.
 \paperauthor{Mario~Juric}{mjuric@astro.washington.edu}{0000-0003-1996-9252}{University of Washington}{Department of Astronomy}{Seattle}{WA}{98195}{U.S.A}
-%\paperauthor{Sample~Author2}{Author2Email@email.edu}{ORCID_Or_Blank}{Author2 Institution}{Author2 Department}{City}{State/Province}{Postal Code}{Country}
-%\paperauthor{Sample~Author3}{Author3Email@email.edu}{ORCID_Or_Blank}{Author3 Institution}{Author3 Department}{City}{State/Province}{Postal Code}{Country}
+\paperauthor{Tim~Jenness}{tjenness@lsst.org}{0000-0001-5982-167X}{LSST}{Data Management}{Tucson}{AZ}{85719}{USA}
 
 \begin{abstract}
 


### PR DESCRIPTION
Added myself to the list.

Some comments:
1. Don't forget to add the `\paperauthor` section for ADS indexing.
2. The fact they want email addresses of every author is very bad because it stops us reusing affiliation lines. Maybe we could negotiate dropping emails so that we can limit the space usage.
